### PR TITLE
Default values for environment variables

### DIFF
--- a/docker-compose.assets.yml
+++ b/docker-compose.assets.yml
@@ -9,8 +9,8 @@ services:
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
       MYSQL_DATABASE: "AssetDatabase"
-      MYSQL_USER: "USER"
-      MYSQL_PASSWORD: "PASSWORD"
+      MYSQL_USER: "assetManager"
+      MYSQL_PASSWORD: "assetManager"
 
   ovehub-ove-asset-manager:
     image: ovehub/ove-asset-manager:latest
@@ -22,8 +22,8 @@ services:
       s3Client__AccessKey: ""
       s3Client__Secret: ""
       s3Client__ServiceURL: ""
-      ServiceHostUrl: "http:// + hostname or ip & port + /"
-      MariaDB__ConnectionString: "Server=ovehub-ove-asset-db;Port=3306;Database=AssetDatabase;User=USER;Password=PASSWORD;"
+      ServiceHostUrl: "http://localhost:8181"
+      MariaDB__ConnectionString: "Server=ovehub-ove-asset-db;Port=3306;Database=AssetDatabase;User=assetManager;Password=assetManager;"
       MariaDB__Version: "10.4.0" 
 
   ovehub-ove-service-imagetiles:
@@ -36,8 +36,8 @@ services:
       s3Client__AccessKey: ""
       s3Client__Secret: ""
       s3Client__ServiceURL: ""
-      AssetManagerHostUrl: "http:// + hostname or ip & port + /"
-      ServiceHostUrl: "http:// + hostname or ip & port + /"
+      AssetManagerHostUrl: "http://localhost:8181"
+      ServiceHostUrl: "http://localhost:8182"
 
 volumes:
   ovehub-ove-asset-db-data:

--- a/docker-compose.ove.yml
+++ b/docker-compose.ove.yml
@@ -17,6 +17,6 @@ services:
     ports:
     - "8081-8089:8081-8089"
     environment:
-      OVE_HOST: "hostname or public ip + port"
-      TUORIS_HOST: "hostname or public ip + port"
+      OVE_HOST: "http://localhost:8080"
+      TUORIS_HOST: "http://localhost:7080"
 


### PR DESCRIPTION
It is easier to document the installation procedure and also easier for the end user when we have some sensible default values for the environment variables. It is too much of a hassle to get someone to always type it.